### PR TITLE
Add `activerecord-postgis-adapter` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "activerecord-postgis-adapter", "~> 11.0"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,9 @@ GEM
       activemodel (= 8.0.2)
       activesupport (= 8.0.2)
       timeout (>= 0.4.0)
+    activerecord-postgis-adapter (11.0.0)
+      activerecord (~> 8.0.0)
+      rgeo-activerecord (~> 8.0.0)
     activestorage (8.0.2)
       actionpack (= 8.0.2)
       activejob (= 8.0.2)
@@ -239,6 +242,10 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    rgeo (3.0.1)
+    rgeo-activerecord (8.0.0)
+      activerecord (>= 7.0)
+      rgeo (>= 3.0)
     rubocop (1.75.8)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -343,6 +350,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activerecord-postgis-adapter (~> 11.0)
   bootsnap
   brakeman
   debug

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,7 +13,7 @@
 # gem "pg"
 #
 default: &default
-  adapter: postgresql
+  adapter: postgis
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling

--- a/db/migrate/20250530014044_add_postgis_extension_to_database.rb
+++ b/db/migrate/20250530014044_add_postgis_extension_to_database.rb
@@ -1,0 +1,5 @@
+class AddPostgisExtensionToDatabase < ActiveRecord::Migration[8.0]
+  def change
+    enable_extension 'postgis'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_30_014044) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "postgis"
 
 end


### PR DESCRIPTION
This pull request introduces support for PostGIS in the Rails application, enabling spatial data capabilities in the database. Key changes include updating the database adapter, adding the necessary gem, and creating a migration to enable the PostGIS extension.

### PostGIS Integration:

* **Added PostGIS gem**: Included the `activerecord-postgis-adapter` gem in the `Gemfile` to enable ActiveRecord support for PostGIS.
* **Updated database adapter**: Changed the database adapter in `config/database.yml` from `postgresql` to `postgis` to support spatial data.
* **Migration for PostGIS extension**: Added a migration (`db/migrate/20250530014044_add_postgis_extension_to_database.rb`) to enable the `postgis` extension in the database.

### Schema Update:

* **Updated schema file**: Regenerated `db/schema.rb` to reflect the addition of the PostGIS extension.