### PR TITLE
Run `tailwindcss-rails` watch mode in the background

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,6 +36,9 @@ plugin :tmp_restart
 # Run the Solid Queue supervisor inside of Puma for single-server deployments
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
+# Run tailwindcss-rails watch mode in the background (only in development).
+plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]


### PR DESCRIPTION
This pull request introduces a configuration update to the `puma.rb` file, enabling Tailwind CSS watch mode in development environments.

### Configuration updates:

* [`config/puma.rb`](diffhunk://#diff-24409379bdb75ad446bb4e2c18fd4cced1a263b99a3ff96fc3777d8fd8faeab9R39-R41): Added a plugin to run `tailwindcss-rails` in watch mode when the `RAILS_ENV` is set to `development`. This ensures that Tailwind CSS changes are automatically compiled during development.

This will allow us to use `rails server` instead of `bin/dev`