### PR TITLE
Añadir `Species` model

### DIFF
--- a/app/controllers/species_controller.rb
+++ b/app/controllers/species_controller.rb
@@ -1,0 +1,5 @@
+class SpeciesController < ApplicationController
+  def index
+    @species = Species.all
+  end
+end

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["drawer", "overlay"]
+
+  toggle() {
+    this.drawerTarget.classList.toggle("-translate-x-full")
+    this.overlayTarget.classList.toggle("hidden")
+  }
+}

--- a/app/models/species.rb
+++ b/app/models/species.rb
@@ -1,0 +1,2 @@
+class Species < ApplicationRecord
+end

--- a/app/models/species.rb
+++ b/app/models/species.rb
@@ -1,2 +1,3 @@
 class Species < ApplicationRecord
+  enum :kingdom, [ :animalia, :plantae, :fungi, :protista, :bacteria, :archaea ]
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,5 +3,5 @@
   data-map-icon-url-value="<%= asset_path('leaflet/marker-icon.png') %>"
   data-map-icon-retina-url-value="<%= asset_path('leaflet/marker-icon-2x.png') %>"
   data-map-shadow-url-value="<%= asset_path('leaflet/marker-shadow.png') %>"
-  class="min-h-screen min-w-screen"
+  class="min-h-screen min-w-screen z-0"
 />

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,4 +1,9 @@
 <div class="navbar bg-primary">
+  <div class="flex-none mx-1">
+    <%= button_tag type: "button", class: "btn btn-square btn-ghost text-white hover:text-primary p-1", data: { action: "click->drawer#toggle" } do %>
+      <%= heroicon "bars-3" %>
+    <% end %>
+  </div>
   <div class="flex-1">
     <%= link_to "VGI", root_path, class: "btn btn-ghost text-xl text-white hover:text-primary" %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,8 @@
   </head>
 
   <body>
-    <main class="container min-w-screen">
+    <main class="container min-w-screen" data-controller="drawer">
+      <%= render "shared/drawer" %>
       <%= render "layouts/navbar" %>
       <%= render "shared/toast" %>
 

--- a/app/views/shared/_drawer.html.erb
+++ b/app/views/shared/_drawer.html.erb
@@ -1,0 +1,7 @@
+<div data-drawer-target="drawer" class="fixed inset-y-0 w-64 bg-white transform -translate-x-full transition-transform duration-300 z-50 space-y-2 font-semibold text-sm px-3" >
+  <ul class="space-y-2 font-bold my-4">
+    <li><%= link_to "Species", species_index_path, class: "flex items-center p-2 text-gray-900 rounded-sm hover:bg-primary hover:text-white" %></li>
+  </ul>
+</div>
+
+<div data-drawer-target="overlay" data-action="click->drawer#toggle" class="fixed inset-0 bg-black/30 hidden z-40"></div>

--- a/app/views/species/index.html.erb
+++ b/app/views/species/index.html.erb
@@ -1,0 +1,33 @@
+
+<div class="overflow-x-auto rounded-box border border-base-content/5 bg-base-100 mx-4">
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Nombre científico</th>
+        <th>Nombre común</th>
+        <th>Epíteto</th>
+        <th>Reino</th>
+        <th>Familia</th>
+        <th>Genus</th>
+        <th>Orden</th>
+        <th>Clase</th>
+        <th>Filo</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @species.each do |species| %>
+        <tr>
+          <td><%= species.scientific_name %></td>
+          <td><%= species.common_name %></td>
+          <td><%= species.epithet %></td>
+          <td><%= species.kingdom %></td>
+          <td><%= species.family %></td>
+          <td><%= species.genus %></td>
+          <td><%= species.order %></td>
+          <td><%= species.class_name %></td>
+          <td><%= species.phylum %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,6 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users, except: [ :create ]
   end
+
+  resources :species, only: [ :index ]
 end

--- a/db/migrate/20250605020853_create_species.rb
+++ b/db/migrate/20250605020853_create_species.rb
@@ -1,0 +1,18 @@
+class CreateSpecies < ActiveRecord::Migration[8.0]
+  def change
+    create_table :species do |t|
+      t.integer :kingdom, null: false
+      t.string :phylum
+      t.string :class_name
+      t.string :order
+      t.string :family
+      t.string :genus, null: false
+      t.string :epithet, null: false
+      t.string :scientific_name, null: false
+      t.string :common_name
+
+      t.timestamps
+    end
+    add_index :species, :scientific_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_30_030033) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_05_020853) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
+
+  create_table "species", force: :cascade do |t|
+    t.integer "kingdom", null: false
+    t.string "phylum"
+    t.string "class_name"
+    t.string "order"
+    t.string "family"
+    t.string "genus", null: false
+    t.string "epithet", null: false
+    t.string "scientific_name", null: false
+    t.string "common_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["scientific_name"], name: "index_species_on_scientific_name", unique: true
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,58 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+Species.find_or_create_by(scientific_name: "Homo sapiens") do |species|
+  species.kingdom = :animalia
+  species.phylum = "Chordata"
+  species.class_name = "Mammalia"
+  species.order = "Primates"
+  species.family = "Hominidae"
+  species.genus = "Homo"
+  species.epithet = "sapiens"
+  species.common_name = "Human"
+end
+
+Species.find_or_create_by(scientific_name: "Canis lupus") do |species|
+  species.kingdom = :animalia
+  species.phylum = "Chordata"
+  species.class_name = "Mammalia"
+  species.order = "Carnivora"
+  species.family = "Canidae"
+  species.genus = "Canis"
+  species.epithet = "lupus"
+  species.common_name = "Gray wolf"
+end
+
+Species.find_or_create_by(scientific_name: "Rosa canina") do |species|
+  species.kingdom = :plantae
+  species.phylum = "Magnoliophyta"
+  species.class_name = "Magnoliopsida"
+  species.order = "Rosales"
+  species.family = "Rosaceae"
+  species.genus = "Rosa"
+  species.epithet = "canina"
+  species.common_name = "Dog rose"
+end
+
+Species.find_or_create_by(scientific_name: "Agaricus bisporus") do |species|
+  species.kingdom = :fungi
+  species.phylum = "Basidiomycota"
+  species.class_name = "Agaricomycetes"
+  species.order = "Agaricales"
+  species.family = "Agaricaceae"
+  species.genus = "Agaricus"
+  species.epithet = "bisporus"
+  species.common_name = "White mushroom"
+end
+
+Species.find_or_create_by(scientific_name: "Escherichia coli") do |species|
+  species.kingdom = :bacteria
+  species.phylum = "Proteobacteria"
+  species.class_name = "Gammaproteobacteria"
+  species.order = "Enterobacterales"
+  species.family = "Enterobacteriaceae"
+  species.genus = "Escherichia"
+  species.epithet = "coli"
+  species.common_name = "E. coli"
+end


### PR DESCRIPTION
#### Summary

Este PR añade el modelo `species` el cual servira para modelar las especies invasoras.

Se añade un drawer para acceder facilmente a las distintas partes de la aplicación.

Se añade un index